### PR TITLE
Fix/improve resolving / wait_for_txt

### DIFF
--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -142,7 +142,7 @@ class ResolveDirectlyFromNameServers(object):
             for nameserver in nameservers:
                 nameserver_ips.update(self._lookup_address(nameserver))
             resolver.nameservers = sorted(nameserver_ips)
-            self.cache[(cache_index, 'resolver')] = resolver
+            self.cache[cache_index] = resolver
         return resolver
 
     def resolve_nameservers(self, target, resolve_addresses=False):

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -57,12 +57,19 @@ class ResolveDirectlyFromNameServers(object):
                     raise exc
                 retry += 1
 
-    def _lookup_ns_names(self, target, nameservers=None):
-        if nameservers is None or self.always_ask_default_resolver:
-            nameservers = self.default_nameservers
+    def _lookup_ns_names(self, target, nameservers=None, nameserver_ips=None):
+        if self.always_ask_default_resolver:
+            nameservers = None
+            nameserver_ips = self.default_nameservers
+        if nameservers is None and nameserver_ips is None:
+            nameserver_ips = self.default_nameservers
+        if not nameserver_ips and nameservers:
+            nameserver_ips = self._lookup_address(nameservers[0])
+        if not nameserver_ips:
+            raise ResolveError('Have neither nameservers nor nameserver IPs')
 
         query = dns.message.make_query(target, dns.rdatatype.NS)
-        response = self._handle_timeout(dns.query.udp, query, nameservers[0], timeout=self.timeout)
+        response = self._handle_timeout(dns.query.udp, query, nameserver_ips[0], timeout=self.timeout)
         self._handle_reponse_errors(target, response)
 
         cname = None
@@ -100,21 +107,21 @@ class ResolveDirectlyFromNameServers(object):
         return result
 
     def _do_lookup_ns(self, target):
-        nameservers = self.default_nameservers
+        nameserver_ips = self.default_nameservers
+        nameservers = None
         for i in range(2, len(target.labels) + 1):
             target_part = target.split(i)[1]
             _nameservers = self.cache.get((str(target_part), 'ns'))
             if _nameservers is None:
-                nameserver_names, cname = self._lookup_ns_names(target_part, nameservers=nameservers)
+                nameserver_names, cname = self._lookup_ns_names(target_part, nameservers=nameservers, nameserver_ips=nameserver_ips)
                 if nameserver_names is not None:
-                    nameservers = []
-                    for nameserver_name in nameserver_names:
-                        nameservers.extend(self._lookup_address(nameserver_name))
+                    nameservers = nameserver_names
 
                 self.cache[(str(target_part), 'ns')] = nameservers
                 self.cache[(str(target_part), 'cname')] = cname
             else:
                 nameservers = _nameservers
+            nameserver_ips = None
 
         return nameservers
 
@@ -130,12 +137,21 @@ class ResolveDirectlyFromNameServers(object):
         if resolver is None:
             resolver = dns.resolver.Resolver(configure=False)
             resolver.timeout = self.timeout
-            resolver.nameservers = nameservers
+            nameserver_ips = set()
+            for nameserver in nameservers:
+                nameserver_ips.update(self._lookup_address(nameserver))
+            resolver.nameservers = sorted(nameserver_ips)
             self.cache[(str(dnsname), 'resolver')] = resolver
         return resolver
 
-    def resolve_nameservers(self, target):
-        return sorted(self._lookup_ns(dns.name.from_unicode(to_text(target))))
+    def resolve_nameservers(self, target, resolve_addresses=False):
+        nameservers = self._lookup_ns(dns.name.from_unicode(to_text(target)))
+        if resolve_addresses:
+            nameserver_ips = set()
+            for nameserver in nameservers:
+                nameserver_ips.update(self._lookup_address(nameserver))
+            nameservers = list(nameserver_ips)
+        return sorted(nameservers)
 
     def resolve(self, target, **kwargs):
         dnsname = dns.name.from_unicode(to_text(target))

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -66,7 +66,7 @@ class ResolveDirectlyFromNameServers(object):
         if not nameserver_ips and nameservers:
             nameserver_ips = self._lookup_address(nameservers[0])
         if not nameserver_ips:
-            raise ResolveError('Have neither nameservers nor nameserver IPs')
+            raise ResolverError('Have neither nameservers nor nameserver IPs')
 
         query = dns.message.make_query(target, dns.rdatatype.NS)
         response = self._handle_timeout(dns.query.udp, query, nameserver_ips[0], timeout=self.timeout)

--- a/tests/integration/targets/wait_for_txt/tasks/main.yml
+++ b/tests/integration/targets/wait_for_txt/tasks/main.yml
@@ -18,9 +18,11 @@
       - success.records | length == 2
       - success.records[0].name == 'github.com'
       - success.records[0].done == true
+      - "'values' in success.records[0]"
       - success.records[0].check_count == 1
       - success.records[1].name == 'github.io'
       - success.records[1].done == true
+      - "'values' in success.records[1]"
       - success.records[1].check_count == 1
 
 - name: Wait for non-existing TXT entry

--- a/tests/unit/plugins/module_utils/test_resolver.py
+++ b/tests/unit/plugins/module_utils/test_resolver.py
@@ -188,7 +188,7 @@ def test_resolver():
                 assert resolver.resolve_nameservers('example.com', resolve_addresses=True) == ['3.3.3.3']
                 # www.example.com is a CNAME for example.org
                 rrset_dict = resolver.resolve('www.example.com')
-                assert list(rrset_dict.keys()) == ['ns.example.com', 'ns.example.org']
+                assert sorted(rrset_dict.keys()) == ['ns.example.com', 'ns.example.org']
                 rrset = rrset_dict['ns.example.com']
                 assert len(rrset) == 1
                 assert rrset.name == dns.name.from_unicode(u'example.org', origin=None)

--- a/tests/unit/plugins/modules/test_wait_for_txt.py
+++ b/tests/unit/plugins/modules/test_wait_for_txt.py
@@ -51,30 +51,12 @@ class TestWaitForTXT(ModuleTestCase):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
                 {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
-                {
                     'target': 'ns.example.com',
                     'lifetime': 10,
                     'result': create_mock_answer(dns.rrset.from_rdata(
                         'ns.example.com',
                         300,
                         dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '3.3.3.3'),
-                    )),
-                },
-                {
-                    'target': 'ns.org',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.3.3'),
                     )),
                 },
                 {
@@ -201,15 +183,6 @@ class TestWaitForTXT(ModuleTestCase):
     def test_double(self):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
-                {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
                 {
                     'target': 'ns.example.com',
                     'lifetime': 10,
@@ -362,15 +335,6 @@ class TestWaitForTXT(ModuleTestCase):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
                 {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
-                {
                     'target': 'ns.example.com',
                     'lifetime': 10,
                     'result': create_mock_answer(dns.rrset.from_rdata(
@@ -475,15 +439,6 @@ class TestWaitForTXT(ModuleTestCase):
     def test_superset(self):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
-                {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
                 {
                     'target': 'ns.example.com',
                     'lifetime': 10,
@@ -632,15 +587,6 @@ class TestWaitForTXT(ModuleTestCase):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
                 {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
-                {
                     'target': 'ns.example.com',
                     'lifetime': 10,
                     'result': create_mock_answer(dns.rrset.from_rdata(
@@ -749,15 +695,6 @@ class TestWaitForTXT(ModuleTestCase):
     def test_equals(self):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
-                {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
                 {
                     'target': 'ns.example.com',
                     'lifetime': 10,
@@ -871,15 +808,6 @@ class TestWaitForTXT(ModuleTestCase):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
                 {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
-                {
                     'target': 'ns.example.com',
                     'lifetime': 10,
                     'result': create_mock_answer(dns.rrset.from_rdata(
@@ -992,15 +920,6 @@ class TestWaitForTXT(ModuleTestCase):
     def test_timeout(self):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
-                {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
                 {
                     'target': 'ns.example.com',
                     'lifetime': 10,
@@ -1233,30 +1152,12 @@ class TestWaitForTXT(ModuleTestCase):
         resolver = mock_resolver(['1.1.1.1'], {
             ('1.1.1.1', ): [
                 {
-                    'target': 'ns.com',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.2.2'),
-                    )),
-                },
-                {
                     'target': 'ns.example.com',
                     'lifetime': 10,
                     'result': create_mock_answer(dns.rrset.from_rdata(
                         'ns.example.com',
                         300,
                         dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '3.3.3.3'),
-                    )),
-                },
-                {
-                    'target': 'ns.org',
-                    'lifetime': 10,
-                    'result': create_mock_answer(dns.rrset.from_rdata(
-                        'ns.com',
-                        300,
-                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, '2.2.3.3'),
                     )),
                 },
                 {

--- a/tests/unit/plugins/modules/test_wait_for_txt.py
+++ b/tests/unit/plugins/modules/test_wait_for_txt.py
@@ -69,7 +69,19 @@ class TestWaitForTXT(ModuleTestCase):
                     )),
                 },
             ],
-            ('3.3.3.3', '4.4.4.4', ): [
+            ('3.3.3.3', ): [
+                {
+                    'target': dns.name.from_unicode(u'example.org'),
+                    'rdtype': dns.rdatatype.TXT,
+                    'lifetime': 10,
+                    'result': create_mock_answer(dns.rrset.from_rdata(
+                        'example.org',
+                        300,
+                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.TXT, 'asdf'),
+                    )),
+                },
+            ],
+            ('4.4.4.4', ): [
                 {
                     'target': dns.name.from_unicode(u'example.org'),
                     'rdtype': dns.rdatatype.TXT,
@@ -177,7 +189,10 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 1
         assert exc.value.args[0]['records'][0]['name'] == 'www.example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['asdf']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['asdf'],
+            'ns.example.org': ['asdf'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 1
 
     def test_double(self):
@@ -324,11 +339,15 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 2
         assert exc.value.args[0]['records'][0]['name'] == 'www.example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['asdf']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['asdf'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 3
         assert exc.value.args[0]['records'][1]['name'] == 'mail.example.com'
         assert exc.value.args[0]['records'][1]['done'] is True
-        assert exc.value.args[0]['records'][1]['values'] == ['any bar']
+        assert exc.value.args[0]['records'][1]['values'] == {
+            'ns.example.com': ['any bar'],
+        }
         assert exc.value.args[0]['records'][1]['check_count'] == 1
 
     def test_subset(self):
@@ -433,7 +452,9 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 1
         assert exc.value.args[0]['records'][0]['name'] == 'example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['foo bar', 'another one', 'asdf']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['foo bar', 'another one', 'asdf'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 3
 
     def test_superset(self):
@@ -576,11 +597,15 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 2
         assert exc.value.args[0]['records'][0]['name'] == 'www.example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['asdf', 'bee']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['asdf', 'bee'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 3
         assert exc.value.args[0]['records'][1]['name'] == 'mail.example.com'
         assert exc.value.args[0]['records'][1]['done'] is True
-        assert exc.value.args[0]['records'][1]['values'] == []
+        assert exc.value.args[0]['records'][1]['values'] == {
+            'ns.example.com': [],
+        }
         assert exc.value.args[0]['records'][1]['check_count'] == 1
 
     def test_superset_not_empty(self):
@@ -689,7 +714,9 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 1
         assert exc.value.args[0]['records'][0]['name'] == 'example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['bumble', 'bee']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['bumble', 'bee'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 4
 
     def test_equals(self):
@@ -801,7 +828,9 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 1
         assert exc.value.args[0]['records'][0]['name'] == 'example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['bumble bee', 'wizard', 'foo']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['bumble bee', 'wizard', 'foo'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 4
 
     def test_equals_ordered(self):
@@ -914,7 +943,9 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 1
         assert exc.value.args[0]['records'][0]['name'] == 'example.com'
         assert exc.value.args[0]['records'][0]['done'] is True
-        assert exc.value.args[0]['records'][0]['values'] == ['foo', 'bumble bee', 'wizard']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['foo', 'bumble bee', 'wizard'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 4
 
     def test_timeout(self):
@@ -1063,11 +1094,15 @@ class TestWaitForTXT(ModuleTestCase):
         assert len(exc.value.args[0]['records']) == 2
         assert exc.value.args[0]['records'][0]['name'] == 'www.example.com'
         assert exc.value.args[0]['records'][0]['done'] is False
-        assert exc.value.args[0]['records'][0]['values'] == ['asdfasdf']
+        assert exc.value.args[0]['records'][0]['values'] == {
+            'ns.example.com': ['asdfasdf'],
+        }
         assert exc.value.args[0]['records'][0]['check_count'] == 3
         assert exc.value.args[0]['records'][1]['name'] == 'mail.example.com'
         assert exc.value.args[0]['records'][1]['done'] is True
-        assert exc.value.args[0]['records'][1]['values'] == ['any bar']
+        assert exc.value.args[0]['records'][1]['values'] == {
+            'ns.example.com': ['any bar'],
+        }
         assert exc.value.args[0]['records'][1]['check_count'] == 1
 
     def test_nxdomain(self):


### PR DESCRIPTION
1. Too many IP addresses are looked up (that are never used). (Fixed in 70adfe751bc07c852fd8252cc606842cc02e10b4.)
2. As opposed to claimed, it does not check **all** nameservers for the TXT entry. (Still to fix.)